### PR TITLE
:arrow_up: Upgrade Bitwarden RS to 1.15.1

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.2.0
 ###############################################################################
 ARG BITWARDEN_ARCH
 # hadolint ignore=DL3006
-FROM "bitwardenrs/server:1.15.0${BITWARDEN_ARCH}" as bitwarden
+FROM "bitwardenrs/server:1.15.1${BITWARDEN_ARCH}" as bitwarden
 
 ###############################################################################
 # Build the actual add-on.


### PR DESCRIPTION
Upgrade BitwardenRS to 1.15.1

https://github.com/dani-garcia/bitwarden_rs/releases

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><img src="https://avatars1.githubusercontent.com/u/725423?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicons/favicon.svg" height="14"> GitHub</div><div><strong><a href="https://github.com/dani-garcia/bitwarden_rs">dani-garcia/bitwarden_rs</a></strong></div><div>Unofficial Bitwarden compatible server written in Rust - dani-garcia/bitwarden_rs</div></blockquote>