### PR TITLE
⬆️ Upgrades BitwardenRS to 1.16.3

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.2.1
 ###############################################################################
 ARG BITWARDEN_ARCH
 # hadolint ignore=DL3006
-FROM "bitwardenrs/server:1.16.0${BITWARDEN_ARCH}" as bitwarden
+FROM "bitwardenrs/server:1.16.3${BITWARDEN_ARCH}" as bitwarden
 
 ###############################################################################
 # Build the actual add-on.


### PR DESCRIPTION
In the docker file, bitwarden_rs has been changed to the latest version.

https://github.com/hassio-addons/addon-bitwarden/issues/35 to fix the problems on the link.

Reference link: https://github.com/dani-garcia/bitwarden_rs/issues/1084