### PR TITLE
:arrow_up: Upgrades BitwardenRS to 1.17.0

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.2.1
 ###############################################################################
 ARG BITWARDEN_ARCH
 # hadolint ignore=DL3006
-FROM "bitwardenrs/server:1.16.0${BITWARDEN_ARCH}" as bitwarden
+FROM "bitwardenrs/server:1.17.0${BITWARDEN_ARCH}" as bitwarden
 
 ###############################################################################
 # Build the actual add-on.
@@ -26,7 +26,7 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        nginx=1.14.2-2+deb10u1 \
+        nginx=1.14.2-2+deb10u3 libpq5 libmariadb3 \
     && apt-get clean \
     && rm -f -r \
         /etc/nginx \


### PR DESCRIPTION
# Proposed Changes

To make 1.17.0 work
- Update nginx from 1.14.2-2+deb10u1 to deb10u3
- Include postgres drivers with libpq5
- Include mysql drivers with libmariadb3

Testing on my personal HA instance and it has been working great.

I added it as a custom add-on repo that is available for others to
test as well. https://github.com/mww/addon-bitwarden

## Related Issues

> ([Github link][autolink-references] Unlock in APP doesn't work)

[autolink-references]: https://github.com/hassio-addons/addon-bitwarden/issues/35