### PR TITLE
Update Dockerfile to new RS version 1.18.0

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.2.1
 ###############################################################################
 ARG BITWARDEN_ARCH
 # hadolint ignore=DL3006
-FROM "bitwardenrs/server:1.16.0${BITWARDEN_ARCH}" as bitwarden
+FROM "bitwardenrs/server:1.18.0${BITWARDEN_ARCH}" as bitwarden
 
 ###############################################################################
 # Build the actual add-on.


### PR DESCRIPTION
There's is a naughty bug in 1.16.0 that renders the mac desktop client practically useless.
See https://github.com/bitwarden/browser/issues/1424
Version 1.18.0 should contain a fix.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/