### PR TITLE
Prevent logging of access tokens by nginx

### DIFF
--- a/bitwarden/rootfs/etc/nginx/nginx.conf
+++ b/bitwarden/rootfs/etc/nginx/nginx.conf
@@ -31,7 +31,12 @@ http {
                              '$http_x_forwarded_for($remote_addr) '
                              '$request ($http_user_agent)';
 
-    access_log              /proc/1/fd/1 homeassistant;
+    map $arg_access_token $loggable {
+        default 0;
+        ''      1;
+    }
+
+    access_log              /proc/1/fd/1 homeassistant if=$loggable;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

I noticed logs like this from the bitwarden add-on:

```
[29/Mar/2021:16:42:13 -0400] 101 <redacted IPs>(172.30.32.1) GET /notifications/hub?access_token=<redacted> HTTP/1.1 (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.30 Safari/537.36)
```

Access tokens don't seem like something we should be logging so I modified the access log directive in `nginx.conf` to only log requests without an `access_token` parameter.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
