### PR TITLE
Cleanup NGinx config

### DIFF
--- a/bitwarden/rootfs/etc/cont-init.d/nginx.sh
+++ b/bitwarden/rootfs/etc/cont-init.d/nginx.sh
@@ -5,7 +5,6 @@
 # ==============================================================================
 declare certfile
 declare keyfile
-declare max_body_size
 
 bashio::config.require.ssl
 
@@ -19,11 +18,3 @@ if bashio::config.true 'ssl'; then
 else
     mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
 fi
-
-max_body_size="10M"
-# Increase body size to match config
-if bashio::config.has_value 'request_size_limit'; then
-    max_body_size=$(bashio::config 'request_size_limit')
-fi
-sed -i "s/%%max_body_size%%/${max_body_size}/g" \
-    /etc/nginx/includes/server_params.conf

--- a/bitwarden/rootfs/etc/nginx/includes/server_params.conf
+++ b/bitwarden/rootfs/etc/nginx/includes/server_params.conf
@@ -4,5 +4,3 @@ server_name     $hostname;
 add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
-
-client_max_body_size %%max_body_size%%;


### PR DESCRIPTION
# Proposed Changes

The proxy doesn't have to match. It can just have a big size (which it already has).
This PR cleans up the logic a bit.
