### PR TITLE
Add domain configuration option

### DIFF
--- a/bitwarden/config.yaml
+++ b/bitwarden/config.yaml
@@ -27,3 +27,4 @@ schema:
   certfile: str
   keyfile: str
   request_size_limit: int?
+  domain: str?

--- a/bitwarden/rootfs/etc/services.d/bitwarden/run
+++ b/bitwarden/rootfs/etc/services.d/bitwarden/run
@@ -75,6 +75,11 @@ fi
 export WEBSOCKET_ENABLED=true
 export WEBSOCKET_PORT=8080
 
+# Set domain
+if bashio::config.has_value 'domain'; then
+    export DOMAIN=$(bashio::config 'domain')
+fi
+
 # Run the Bitwarden server
 bashio::log.info 'Starting the Vaultwarden server...'
 cd /opt || bashio::exit.nok

--- a/bitwarden/translations/en.yaml
+++ b/bitwarden/translations/en.yaml
@@ -24,5 +24,11 @@ configuration:
       Optionally set the size limit of HTTP requests on the API of
       Vaultwarden. This might be needed to support larger imports.
       The default is 10485760, which is 10MB.
+  domain:
+    name: The domain of the server
+    description: >-
+      The domain of the Home Assistant server. Necessary for
+      functionality such as attachments, downloads, email links,
+      and U2F.
 network:
   7277/tcp: Web interface


### PR DESCRIPTION
This adds a domain configuration option. It allows attachment downloads, email links and U2F. It should fix the
`There was a problem reading the security key. Try again.` and
`DOMException: The relying party ID is not a registrable domain suffix of, nor equal to the current domain.` 
errors caused when attempting to register a WebAuthn security key.