### PR TITLE
⬆️ Upgrades Vaultwarden to 1.25.1

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:6.1.0
 ###############################################################################
 # Get prebuild containers from Vaultwarden
 ###############################################################################
-FROM "vaultwarden/server:1.25.0" as vaultwarden
+FROM "vaultwarden/server:1.25.1" as vaultwarden
 
 ###############################################################################
 # Build the actual add-on.


### PR DESCRIPTION
# Proposed Changes
Upgrade Vaultwarden to the latest Version 1.25.1
Changelog: https://github.com/dani-garcia/vaultwarden/releases/tag/1.25.1
All Vaultwarden changes: https://github.com/dani-garcia/vaultwarden/compare/1.25.0...1.25.1

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
