### PR TITLE
⬆️ Upgrades Vaultwarden to 1.27.0

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:6.2.0
 ###############################################################################
 # Get prebuild containers from Vaultwarden
 ###############################################################################
-FROM "vaultwarden/server:1.26.0" as vaultwarden
+FROM "vaultwarden/server:1.27.0" as vaultwarden
 
 ###############################################################################
 # Build the actual add-on.


### PR DESCRIPTION
# Proposed Changes

Upgrades vaultwarden to the latest release
https://github.com/dani-garcia/vaultwarden/releases/tag/1.27.0

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
