### PR TITLE
Remove deprecated websocket config

### DIFF
--- a/bitwarden/rootfs/etc/nginx/includes/upstream.conf
+++ b/bitwarden/rootfs/etc/nginx/includes/upstream.conf
@@ -1,7 +1,3 @@
 upstream backend {
     server 127.0.0.1:80;
 }
-
-upstream wsbackend {
-    server 127.0.0.1:8080;
-}

--- a/bitwarden/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/bitwarden/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -12,12 +12,4 @@ server {
         proxy_pass http://backend;
     }
 
-    location /notifications/hub {
-        proxy_pass http://wsbackend;
-    }
-
-    location /notifications/hub/negotiate {
-        proxy_pass http://backend;
-    }
-
 }

--- a/bitwarden/rootfs/etc/nginx/servers/direct.disabled
+++ b/bitwarden/rootfs/etc/nginx/servers/direct.disabled
@@ -8,12 +8,4 @@ server {
         proxy_pass http://backend;
     }
 
-    location /notifications/hub {
-        proxy_pass http://wsbackend;
-    }
-
-    location /notifications/hub/negotiate {
-        proxy_pass http://backend;
-    }
-
 }

--- a/bitwarden/rootfs/etc/s6-overlay/s6-rc.d/vaultwarden/run
+++ b/bitwarden/rootfs/etc/s6-overlay/s6-rc.d/vaultwarden/run
@@ -72,10 +72,6 @@ if bashio::config.has_value 'request_size_limit'; then
     export ROCKET_LIMITS="{json=${request_size_limit}}"
 fi
 
-# Always enable Websockets
-export WEBSOCKET_ENABLED=true
-export WEBSOCKET_PORT=8080
-
 # Run the Bitwarden server
 bashio::log.info 'Starting the Vaultwarden server...'
 cd /opt || bashio::exit.nok


### PR DESCRIPTION
# Proposed Changes

Vaultwarden enables websockets on the backend port by default, and no longer requires the websocket config (since v1.29.0). In addition, with v1.31.0, the websocket config will become deprecated. See also:

- https://github.com/dani-garcia/vaultwarden/releases/tag/1.30.0
- https://github.com/dani-garcia/vaultwarden/wiki/Enabling-WebSocket-notifications

This PR removes the websocket config from nginx and the vaultwarden run script.

## Related Issues

No issues yet.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
