### PR TITLE
Add ingress

### DIFF
--- a/bitwarden/config.yaml
+++ b/bitwarden/config.yaml
@@ -11,6 +11,9 @@ arch:
   - aarch64
   - amd64
   - armv7
+ingress: true
+ingress_port: 7277
+ingress_stream: true
 ports:
   7277/tcp: 7277
 ports_description:


### PR DESCRIPTION
# Proposed Changes

> I opened the addon for the first time and wanted to try it. I'm  checking alternative password managers. It cannot be done from HA without setting up certificates for the initial login.  Establishing Ingress let me create an account so that I could try the addon.

## Related Issues

> N/A

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration for Vaultwarden with new ingress settings for improved network access.
		- Ingress enabled by default.
		- Specified port for ingress traffic set to 7277.
		- Support for streaming over ingress is now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->