### PR TITLE
bump libpq5 to 17.7 in Dockerfile

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         libmariadb-dev-compat=1:11.8.3-0+deb13u1 \
-        libpq5=17.6-0+deb13u1 \
+        libpq5=17.7-0+deb13u1 \
         nginx=1.26.3-3+deb13u1 \
         sqlite3=3.46.1-7 \
     && apt-get clean \


### PR DESCRIPTION
# Proposed Changes

bump libpq5 to fix missing package error that resulted in CI Workflow #720 failing and preventing the creation of the latest vaultwarden package in the community addons repo

<img width="1412" height="557" alt="vaultwarden-build-fail" src="https://github.com/user-attachments/assets/b4d3cfa0-bb68-4d1e-95ed-74774f3516d8" />

https://github.com/hassio-addons/addon-bitwarden/actions/runs/21046843950

## Related Issues

This PR fixes https://github.com/hassio-addons/addon-bitwarden/issues/392



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database library dependency to a minor version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->