### PR TITLE
[Feature] Add extra port to deny /admin access

### DIFF
--- a/vaultwarden/config.yaml
+++ b/vaultwarden/config.yaml
@@ -11,8 +11,10 @@ arch:
   - amd64
 ports:
   7277/tcp: 7277
+  7278/tcp: 7278
 ports_description:
-  7277/tcp: Vaultwarden Web interface
+  7277/tcp: Vaultwarden Web interface with admin access
+  7278/tcp: Vaultwarden Web interface without admin access
 map:
   - ssl
 options:

--- a/vaultwarden/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/vaultwarden/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -12,5 +12,25 @@ server {
     location / {
         proxy_pass http://backend;
     }
+}
 
+server {
+    listen 7278 ssl;
+    listen [::]:7278 ssl;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/ssl_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    ssl_certificate /ssl/%%certfile%%;
+    ssl_certificate_key /ssl/%%keyfile%%;
+
+    location /admin {
+        deny all;
+        return 403;
+    }
+
+    location / {
+        proxy_pass http://backend;
+    }
 }

--- a/vaultwarden/rootfs/etc/nginx/servers/direct.disabled
+++ b/vaultwarden/rootfs/etc/nginx/servers/direct.disabled
@@ -10,3 +10,22 @@ server {
     }
 
 }
+
+server {
+server {
+    listen 7278 default_server;
+    listen [::]:7278 default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    location /admin {
+        deny all;
+        return 403;
+    }
+
+    location / {
+        proxy_pass http://backend;
+    }
+
+}

--- a/vaultwarden/rootfs/etc/nginx/servers/direct.disabled
+++ b/vaultwarden/rootfs/etc/nginx/servers/direct.disabled
@@ -12,7 +12,6 @@ server {
 }
 
 server {
-server {
     listen 7278 default_server;
     listen [::]:7278 default_server;
 

--- a/vaultwarden/translations/en.yaml
+++ b/vaultwarden/translations/en.yaml
@@ -25,4 +25,5 @@ configuration:
       Vaultwarden. This might be needed to support larger imports.
       The default is 10485760, which is 10MB.
 network:
-  7277/tcp: Web interface
+  7277/tcp: Web interface with admin access
+  7278/tcp: Web interface without admin access


### PR DESCRIPTION
# Proposed Changes

Linked to my comment on the issue #411 , here a small modification in order to expose a new port 7278 with /admin endpoint denied. 

## Related Issues

https://github.com/hassio-addons/app-vaultwarden/issues/411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated non-admin web interface endpoint (7278) that restricts access to administrative functions
  * Clarified the existing web interface as admin-access (7277)

* **Documentation**
  * Updated UI/network labels and translations to reflect separate admin and non-admin endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->