### PR TITLE
Add SSO (OpenID Connect) configuration support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force LF line endings on checkout for all text files.
+# The rootfs is copied into a Linux container image; CRLF endings break
+# s6-overlay service files and bash scripts.
+* text=auto eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.ico binary

--- a/vaultwarden/DOCS.md
+++ b/vaultwarden/DOCS.md
@@ -51,6 +51,17 @@ ssl: false
 certfile: fullchain.pem
 keyfile: privkey.pem
 request_size_limit: 10485760
+domain: https://vaultwarden.example.com
+sso_enabled: true
+sso_authority: https://authentik.example.com/application/o/vaultwarden/
+sso_client_id: myclientid
+sso_client_secret: myclientsecret
+sso_scopes: email profile offline_access
+sso_only: false
+sso_signups_match_email: true
+env_vars:
+  - name: SSO_PKCE
+    value: "true"
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -101,6 +112,102 @@ something smaller than that to prevent API abuse and possible DOS attack,
 especially if running with limited resources.
 
 To set the limit, you can use this setting: 10MB would be `10485760`.
+
+### Option: `domain`
+
+The public URL on which this Vaultwarden instance is reachable, e.g.,
+`https://vaultwarden.example.com`. This sets the `DOMAIN` setting of
+Vaultwarden and is **required when SSO is enabled**, since Vaultwarden
+uses it to build the OpenID Connect redirect URL
+(`<domain>/identity/connect/oidc-signin`).
+
+### Option: `sso_enabled`
+
+Enables/Disables single sign-on via OpenID Connect. Works with any
+OIDC-capable identity provider (Authentik, Keycloak, Authelia, Zitadel,
+Google, etc.). Set it `true` to enable it, `false` otherwise.
+
+When enabled, the `domain`, `sso_authority`, `sso_client_id`, and
+`sso_client_secret` options are required.
+
+**Note**: _SSO in Vaultwarden handles authentication only. The account
+master password is still used to encrypt/decrypt your vault._
+
+### Option: `sso_authority`
+
+The OpenID Connect issuer URL of your identity provider. Vaultwarden
+appends `/.well-known/openid-configuration` to this URL for discovery.
+
+For Authentik, this looks like:
+`https://authentik.example.com/application/o/<application_slug>/`
+
+### Option: `sso_client_id`
+
+The OAuth2/OpenID Connect client ID, as configured in your identity
+provider.
+
+### Option: `sso_client_secret`
+
+The OAuth2/OpenID Connect client secret, as configured in your identity
+provider.
+
+### Option: `sso_scopes`
+
+The scopes requested from the identity provider. Vaultwarden defaults to
+`email profile`. For Authentik, use `email profile offline_access` so
+refresh tokens are issued.
+
+### Option: `sso_allow_unknown_email_verification`
+
+Allow logins from identity providers that do not send the
+`email_verified` claim. Only enable this if you trust your provider to
+verify email addresses. Defaults to `false`.
+
+### Option: `sso_client_cache_expiration`
+
+Number of seconds to cache the identity provider discovery metadata.
+`0` disables caching (the default).
+
+### Option: `sso_only`
+
+Set to `true` to disable email and master password login and require SSO
+for all users. **Make sure SSO login works before enabling this**, or you
+may lock yourself out (the `/admin` panel remains reachable via the admin
+token). Defaults to `false`.
+
+### Option: `sso_signups_match_email`
+
+On a user's first SSO login, link the SSO identity to an existing
+Vaultwarden account with the same email address instead of creating a
+new account. Defaults to `true`.
+
+### Option: `env_vars`
+
+Allows the setting of any additional environment variable for
+Vaultwarden. This can be used to configure any Vaultwarden setting that
+does not have a dedicated option in this app, including all other SSO
+settings (e.g., `SSO_PKCE`, `SSO_ROLES_ENABLED`,
+`SSO_ORGANIZATIONS_ENABLED`, `SSO_AUTH_ONLY_NOT_SESSION`,
+`SSO_MASTER_PASSWORD_POLICY`, `SSO_DEBUG_TOKENS`).
+
+See the [Vaultwarden configuration documentation][vaultwarden-config] and
+the [Vaultwarden SSO documentation][vaultwarden-sso] for all available
+settings.
+
+Example:
+
+```yaml
+env_vars:
+  - name: SSO_PKCE
+    value: "true"
+  - name: SIGNUPS_ALLOWED
+    value: "false"
+```
+
+**Note**: _These environment variables are applied last and therefore
+override any of the other options above. Settings changed in the
+Vaultwarden `/admin` panel are stored in `/data/config.json` and take
+precedence over environment variables._
 
 ## Known issues and limitations
 
@@ -182,3 +289,5 @@ SOFTWARE.
 [releases]: https://github.com/hassio-addons/app-vaultwarden/releases
 [semver]: https://semver.org/spec/v2.0.0.html
 [vaultwarden]: https://github.com/dani-garcia/vaultwarden
+[vaultwarden-config]: https://github.com/dani-garcia/vaultwarden/wiki/Configuration-overview
+[vaultwarden-sso]: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect

--- a/vaultwarden/Dockerfile
+++ b/vaultwarden/Dockerfile
@@ -23,10 +23,10 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        libmariadb-dev-compat=1:11.8.6-0+deb13u1 \
-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
-        sqlite3=3.46.1-7+deb13u1 \
+        libmariadb-dev-compat \
+        libpq5 \
+        nginx \
+        sqlite3 \
     && apt-get clean \
     && rm -f -r \
         /etc/nginx \

--- a/vaultwarden/config.yaml
+++ b/vaultwarden/config.yaml
@@ -19,9 +19,23 @@ options:
   ssl: true
   certfile: fullchain.pem
   keyfile: privkey.pem
+  sso_enabled: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   ssl: bool
   certfile: str
   keyfile: str
   request_size_limit: int?
+  domain: url?
+  sso_enabled: bool
+  sso_authority: url?
+  sso_client_id: str?
+  sso_client_secret: password?
+  sso_scopes: str?
+  sso_allow_unknown_email_verification: bool?
+  sso_client_cache_expiration: int?
+  sso_only: bool?
+  sso_signups_match_email: bool?
+  env_vars:
+    - name: match(^[A-Za-z_][A-Za-z0-9_]*$)
+      value: str

--- a/vaultwarden/config.yaml
+++ b/vaultwarden/config.yaml
@@ -20,6 +20,7 @@ options:
   certfile: fullchain.pem
   keyfile: privkey.pem
   sso_enabled: false
+  env_vars: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   ssl: bool

--- a/vaultwarden/rootfs/etc/s6-overlay/s6-rc.d/vaultwarden/run
+++ b/vaultwarden/rootfs/etc/s6-overlay/s6-rc.d/vaultwarden/run
@@ -8,6 +8,8 @@ declare admin_token
 declare log_level
 declare request_size_limit
 declare secret_key
+declare env_var_name
+declare env_var_value
 
 # Set defaults
 export DATA_FOLDER=/data
@@ -71,6 +73,70 @@ if bashio::config.has_value 'request_size_limit'; then
     request_size_limit=$(bashio::config 'request_size_limit')
     export ROCKET_LIMITS="{json=${request_size_limit}}"
 fi
+
+# Public domain of this Vaultwarden instance (required for SSO)
+if bashio::config.has_value 'domain'; then
+    DOMAIN=$(bashio::config 'domain')
+    export DOMAIN
+fi
+
+# SSO / OpenID Connect
+if bashio::config.true 'sso_enabled'; then
+    bashio::config.require 'domain' \
+        "SSO requires the 'domain' option to be set to the public URL of this instance"
+    bashio::config.require 'sso_authority' \
+        "SSO is enabled, but no 'sso_authority' is configured"
+    bashio::config.require 'sso_client_id' \
+        "SSO is enabled, but no 'sso_client_id' is configured"
+    bashio::config.require 'sso_client_secret' \
+        "SSO is enabled, but no 'sso_client_secret' is configured"
+
+    export SSO_ENABLED=true
+    SSO_AUTHORITY=$(bashio::config 'sso_authority')
+    export SSO_AUTHORITY
+    SSO_CLIENT_ID=$(bashio::config 'sso_client_id')
+    export SSO_CLIENT_ID
+    SSO_CLIENT_SECRET=$(bashio::config 'sso_client_secret')
+    export SSO_CLIENT_SECRET
+
+    if bashio::config.has_value 'sso_scopes'; then
+        SSO_SCOPES=$(bashio::config 'sso_scopes')
+        export SSO_SCOPES
+    fi
+
+    if bashio::config.has_value 'sso_allow_unknown_email_verification'; then
+        SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION=$(bashio::config 'sso_allow_unknown_email_verification')
+        export SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION
+    fi
+
+    if bashio::config.has_value 'sso_client_cache_expiration'; then
+        SSO_CLIENT_CACHE_EXPIRATION=$(bashio::config 'sso_client_cache_expiration')
+        export SSO_CLIENT_CACHE_EXPIRATION
+    fi
+
+    if bashio::config.has_value 'sso_only'; then
+        SSO_ONLY=$(bashio::config 'sso_only')
+        export SSO_ONLY
+    fi
+
+    if bashio::config.has_value 'sso_signups_match_email'; then
+        SSO_SIGNUPS_MATCH_EMAIL=$(bashio::config 'sso_signups_match_email')
+        export SSO_SIGNUPS_MATCH_EMAIL
+    fi
+
+    bashio::log.info 'SSO (OpenID Connect) is enabled'
+else
+    export SSO_ENABLED=false
+fi
+
+# Additional environment variables, for any other Vaultwarden setting.
+# These are applied last, and therefore override any of the above.
+for var in $(bashio::config 'env_vars|keys'); do
+    env_var_name=$(bashio::config "env_vars[${var}].name")
+    env_var_value=$(bashio::config "env_vars[${var}].value")
+    bashio::log.info "Setting environment variable: ${env_var_name}"
+    export "${env_var_name}=${env_var_value}"
+done
 
 # Run the Vaultwarden server
 bashio::log.info 'Starting the Vaultwarden server...'

--- a/vaultwarden/translations/en.yaml
+++ b/vaultwarden/translations/en.yaml
@@ -24,5 +24,65 @@ configuration:
       Optionally set the size limit of HTTP requests on the API of
       Vaultwarden. This might be needed to support larger imports.
       The default is 10485760, which is 10MB.
+  domain:
+    name: Domain
+    description: >-
+      The public URL on which this Vaultwarden instance is reachable,
+      e.g., https://vaultwarden.example.com. Required when SSO is enabled,
+      as it is used to build the OpenID Connect redirect URL.
+  sso_enabled:
+    name: SSO enabled
+    description: >-
+      Enables/Disables single sign-on via OpenID Connect (e.g., Authentik,
+      Keycloak, Authelia, Google, or any other OIDC provider).
+  sso_authority:
+    name: SSO authority
+    description: >-
+      The OpenID Connect issuer URL of your identity provider. For
+      Authentik this looks like
+      https://authentik.example.com/application/o/<application_slug>/.
+  sso_client_id:
+    name: SSO client ID
+    description: >-
+      The OAuth2/OpenID Connect client ID from your identity provider.
+  sso_client_secret:
+    name: SSO client secret
+    description: >-
+      The OAuth2/OpenID Connect client secret from your identity provider.
+  sso_scopes:
+    name: SSO scopes
+    description: >-
+      The OpenID Connect scopes to request. Defaults to
+      "email profile". Add "offline_access" if your provider issues
+      refresh tokens via that scope (Authentik does).
+  sso_allow_unknown_email_verification:
+    name: SSO allow unknown email verification
+    description: >-
+      Allow logins from identity providers that do not report an
+      email_verified claim. Only enable this if you trust your provider.
+      Defaults to false.
+  sso_client_cache_expiration:
+    name: SSO client cache expiration
+    description: >-
+      Cache the identity provider discovery metadata for this many
+      seconds. Set to 0 to disable caching. Defaults to 0.
+  sso_only:
+    name: SSO only
+    description: >-
+      Disable email and master password login and require SSO for all
+      users. Make sure SSO works before enabling this! Defaults to false.
+  sso_signups_match_email:
+    name: SSO signups match email
+    description: >-
+      On first SSO login, link the SSO identity to an existing
+      Vaultwarden account with the same email address instead of
+      creating a new account. Defaults to true.
+  env_vars:
+    name: Additional environment variables
+    description: >-
+      A list of name/value pairs of additional environment variables to
+      pass to Vaultwarden. This allows setting any Vaultwarden
+      configuration option (including any SSO option) that does not have
+      a dedicated option in this app. These override all other options.
 network:
   7277/tcp: Web interface


### PR DESCRIPTION
Adds addon options for Vaultwarden's native SSO support (available since Vaultwarden 1.34.0):

- domain: public URL, required for building the OIDC redirect URL
- sso_enabled: on/off toggle for OpenID Connect login
- sso_authority, sso_client_id, sso_client_secret: provider settings
- sso_scopes, sso_allow_unknown_email_verification, sso_client_cache_expiration, sso_only, sso_signups_match_email
- env_vars: generic name/value list to set any other Vaultwarden setting, including all remaining SSO_* options

Required options are validated at startup when SSO is enabled. Existing options and behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SSO/OpenID Connect support with configurable domain, authority, client ID/secret, scopes, and SSO-only behavior.
  * Improved SSO-related login/signup and email verification controls.
  * Added support for injecting additional environment variables via configurable name/value pairs.
* **Documentation**
  * Expanded configuration and option descriptions for all new SSO and extra environment variable settings, including updated reference links and translations.
* **Chores**
  * Updated the Nginx image build to stop pinning Debian package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->