### PR TITLE
⬆️ Update libpq5 and nginx apt pins for Debian 13

### DIFF
--- a/vaultwarden/Dockerfile
+++ b/vaultwarden/Dockerfile
@@ -24,8 +24,8 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         libmariadb-dev-compat=1:11.8.6-0+deb13u1 \
-        libpq5=17.9-0+deb13u1 \
-        nginx=1.26.3-3+deb13u2 \
+        libpq5=17.10-0+deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
         sqlite3=3.46.1-7+deb13u1 \
     && apt-get clean \
     && rm -f -r \


### PR DESCRIPTION
# Proposed Changes

Two of the four pinned apt packages no longer resolve in Debian 13, so the image build fails at the `apt-get install` step:

| package | pinned | candidate in Debian 13 |
| --- | --- | --- |
| `libmariadb-dev-compat` | `1:11.8.6-0+deb13u1` | `1:11.8.6-0+deb13u1` (ok) |
| `libpq5` | `17.9-0+deb13u1` | `17.10-0+deb13u1` |
| `nginx` | `1.26.3-3+deb13u2` | `1.26.3-3+deb13u7` |
| `sqlite3` | `3.46.1-7+deb13u1` | `3.46.1-7+deb13u1` (ok) |

`libmariadb-dev-compat` and `sqlite3` are unchanged and stay pinned as they are, so the existing pinning style is kept intact.

This is what currently makes `Build amd64` fail on #424 (`⬆️ Update vaultwarden/server Docker tag to v1.37.0`). That bump matters beyond a routine dependency update: Vaultwarden 1.37.0 is required for Bitwarden clients v2026.7.0+ (dani-garcia/vaultwarden#7473) — against an older server the browser extension authenticates and syncs, but renders an empty vault — and it carries a number of security advisories.

This PR only gets the build green again. The reason the pin drifted in the first place is a Repology mapping that Renovate cannot resolve, which is #428; without that, `libpq5` will go stale again.

## Verification

Candidate versions checked in a clean `debian:13` container. Since the add-on also builds for aarch64, I checked arm64 separately rather than assuming parity: `libpq5_17.10-0+deb13u1_arm64.deb` and `nginx_1.26.3-3+deb13u7_arm64.deb` both exist with identical version strings, so there is no binNMU divergence.

Built `vaultwarden/Dockerfile` locally for amd64 with these pins, and separately with `vaultwarden/server:1.37.0` to confirm the combination in #424 builds:

```
$ docker run --rm --entrypoint /opt/vaultwarden <image> --version
Vaultwarden 1.37.0
$ docker run --rm --entrypoint nginx <image> -v
nginx version: nginx/1.26.3
```

## Related Issues

Related #425 — the user-facing report of this build failure
Unblocks #424
Related #419 — it advances the same nginx pin, but on its own it does not turn the build green, because `libpq5` is still stale; it currently fails with the same `Build amd64` error
Related #428 — fixes the Renovate mapping so this pin stays current on its own

---

I used Claude Code as an assistant while investigating this and writing it up. The versions above are verified rather than assumed, the build was run locally, and I own the change.
