### PR TITLE
⬆️ Fix Repology mapping for the libpq5 apt pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "deb",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-13' package}}}"
+      "depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-17' package}}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
# Proposed Changes

The custom manager that keeps the apt pins in `vaultwarden/Dockerfile` current maps `libpq5` onto `debian_13/postgresql-13`:

```json
"depNameTemplate": "debian_13/{{{replace 'libpq5' 'postgresql-13' package}}}"
```

Debian 13 ships PostgreSQL 17, so that project does not exist in Repology and Renovate cannot resolve the pin at all. It has therefore never proposed an update for `libpq5`, which is how that pin drifted to a version that no longer resolves in the archive and started failing every image build.

Renovate reports this itself — the Dependency Dashboard (#252) has been carrying it:

> Renovate failed to look up the following dependencies: `Failed to look up repology package debian_13/postgresql-13: no-result`.
>
> - `debian_13/postgresql-13 17.9-0+deb13u1`

So the diagnosis is not new; what has been missing is the one-line correction and the connection to the red builds.

Lookups against `repo=debian_13`, using the same endpoint the Repology datasource uses:

| name | `binname` | `srcname` |
| --- | --- | --- |
| `postgresql-13` | HTTP 404 | HTTP 404 |
| `postgresql-17` | `version 17.10`, `origversion 17.10-0+deb13u1` | same |
| `libpq5` | resolves to project `postgresql-17`, same `origversion` | HTTP 404 |

## Why this pin in particular went stale

Renovate has been proposing updates for the other three apt pins — nginx (#401, #419), sqlite3 (#407), libmariadb-dev-compat (#406) — but never for `libpq5`. Every `libpq5` bump in this repository's history has been a manual one (#85, #100, #180, #189, #393), which fits a lookup that has never resolved.

The consequence is that the same pin has now broken the build twice: #393 in January (closed as handled in #396) and #424 now.

For what it is worth, the mapping looks like it was simply outgrown rather than mistyped: the last maintainer-authored bump, #189, was `libpq5 13.5-0+deb11u1`, and Debian 11 shipped PostgreSQL 13 — so `postgresql-13` was accurate at the time. The distro prefix has since moved to `debian_13` while the PostgreSQL major stayed at 13.

`origversion` is the value that matters here, and `17.10-0+deb13u1` is exactly the pin that is needed — so with this change Renovate should propose the `libpq5` bump on its own from now on.

Two things worth your call:

1. This is the minimal fix and keeps the existing structure, but it will need the same edit again at the next Debian major bump. Dropping the rewrite entirely also works, because `libpq5` resolves as a `binname` to the same project and `origversion` — that variant would survive future PostgreSQL major versions. Happy to switch this PR over if you prefer it.
2. Because `repology` updates are set to `automerge: true`, this one unresolvable pin has been holding back more than itself: #419 has been open since May instead of automerging, failing with the same `Build amd64` error, which in turn blocks #424.

## Related Issues

Related #425 — the user-facing report of the resulting build failure
Follow-up to #426, which advances the two stale pins so the build goes green again

---

I used Claude Code as an assistant while investigating this and writing it up. The lookups above are reproducible with the endpoint named, I checked them rather than assuming them, and I own the change.
